### PR TITLE
Add support for Ollama, Palm, Claude-2, Cohere, Replicate Llama2 CodeLlama (100+LLMs) - LiteLLM

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ import os
 import json
 import re
 import openai
+import litellm
 import requests
 from bs4 import BeautifulSoup
 from graphviz import Digraph
@@ -20,7 +21,7 @@ load_dotenv()
 app = Flask(__name__)
 
 # Set your OpenAI API key
-openai.api_key = os.getenv("OPENAI_API_KEY")
+litellm.api_key = os.getenv("OPENAI_API_KEY")
 response_data = ""
 
 # If Neo4j credentials are set, then Neo4j is used to store information
@@ -130,7 +131,7 @@ def get_response_data():
         return jsonify({"error": "No input provided"}), 400
     print("starting openai call")
     try:
-        completion: KnowledgeGraph = openai.ChatCompletion.create(
+        completion: KnowledgeGraph = litellm.completion(
             model="gpt-3.5-turbo-16k",
             messages=[
                 {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ authors = ["Your Name <you@example.com>"]
 [tool.poetry.dependencies]
 python = ">=3.10.0,<3.11"
 openai = "^0.28.0"
+litellm = ">=0.1.820"
 bs4 = "^0.0.1"
 matplotlib = "^3.7.2"
 networkx = "^3.1"


### PR DESCRIPTION
This PR adds support for the above mentioned LLMs using LiteLLM https://github.com/BerriAI/litellm/ 
LiteLLM is a lightweight package to simplify LLM API calls - use any llm as a drop in replacement for gpt-3.5-turbo. 

Example
```python
from litellm import completion

## set ENV variables
os.environ["OPENAI_API_KEY"] = "openai key"
os.environ["COHERE_API_KEY"] = "cohere key"

messages = [{ "content": "Hello, how are you?","role": "user"}]

# openai call
response = completion(model="gpt-3.5-turbo", messages=messages)

# cohere call
response = completion(model="command-nightly", messages)

# anthropic call
response = completion(model="claude-instant-1", messages=messages)
```
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**Refactor:**
- Switched from `openai` to `litellm` for language model completions. This change enhances the underlying AI capabilities of our application, potentially improving the user experience with more accurate and context-aware responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->