### PR TITLE
restore error-message dialog

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -43,7 +43,14 @@
             <div class="space-y-2 overflow-y-auto" id="history"></div>
         </div>
     </div>
-
+    <div
+        id="error-message"
+        class="fixed w-full h-3 mb-2 bg-red-500 text-white flex items-center justify-between p-4 rounded-md shadow"
+        style="display: none"
+    >
+        <span id="error-text"></span>
+        <span id="error-close" style="cursor: pointer">&times;</span>
+    </div>
     <script>
       const calcNodeWidth = (label) => {
         // null checker added


### PR DESCRIPTION

The error-meesage div was removed in the bc3866ffec5c5f7dc186c55f718816ab036de2d7 commit.
Since the error could no longer be displayed, I restored it.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Summary by CodeRabbit

- New Feature: Added an error message display to the main page. This feature will enhance user experience by providing clear and immediate feedback when an error occurs. The error message, initially hidden, will appear when needed and can be easily dismissed by the user with a close button. This change improves the software's intuitiveness and user-friendliness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->